### PR TITLE
improved sga biobox

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,9 +65,6 @@ RUN cd ${SGA_DIR} && \
     make install && \
     rm -rf ${SGA_DIR}
 
-
-
-
 ADD run /usr/local/bin/
 ADD assemble /usr/local/bin/
 ADD Taskfile /

--- a/assemble
+++ b/assemble
@@ -22,7 +22,7 @@ mkdir -p ${OUTPUT}
 
 # Parse the read locations from this file
 READS=$(yaml2json < ${INPUT} \
-        | jq --raw-output '.arguments[] | select(has("fastq")) | .fastq[].value | "-short \(.)"' \
+        | jq --raw-output '.arguments[] | select(has("fastq")) | .fastq[].value ' \
         | tr '\n' ' ')
 
 #create temporary directory in /tmp

--- a/assemble
+++ b/assemble
@@ -40,8 +40,6 @@ fi
 # Eval evaluates a String as if you would use it on a command line.
 eval ${CMD}
 
-# cp ${TMP_DIR}/contigs.fa ${OUTPUT}
-
 # This command writes yaml into the biobox.yaml until the EOF symbol is reached
 cat << EOF > ${OUTPUT}/biobox.yaml
 version: 0.9.0

--- a/assemble
+++ b/assemble
@@ -8,6 +8,7 @@ set -o nounset
 
 INPUT=/bbx/input/biobox.yaml
 OUTPUT=/bbx/output
+METADATA=/bbx/metadata
 
 # Since this script is the entrypoint to your container
 # you can access the task in `docker run task` as the first argument
@@ -34,6 +35,11 @@ CMD=$(egrep ^${TASK}: /Taskfile | cut -f 2 -d ':')
 if [[ -z ${CMD} ]]; then
   echo "Abort, no task found for '${TASK}'."
   exit 1
+fi
+
+# if /bbx/metadata mounted create log.txt
+if [ -d "$METADATA" ]; then
+  CMD="($CMD) >& $METADATA/log.txt"
 fi
 
 # Run the given task with eval.

--- a/run
+++ b/run
@@ -25,14 +25,6 @@ exec 2>&1
 TMP_DIR=`mktemp -d`
 cd ${TMP_DIR}
 
-# Determine which process to run
-# CMD=$(egrep ^${PROC}: /Taskfile | cut -f 2 -d ':')#
-#if [[ -z ${CMD} ]]; then
-#  echo "Abort, no proc found for '${PROC}'."
-#  exit 1
-#fi
-#eval ${CMD}
-
 ASSEMBLE_OVERLAP=111
 TRIM_LENGTH=400
 

--- a/run
+++ b/run
@@ -6,7 +6,7 @@ set -o nounset
 
 # The first argument is the location of the reads in the container filesystem.
 # The will be present in a read-only directory
-READS=$2
+READS="$@"
 
 OUTPUT=/bbx/output
 

--- a/run
+++ b/run
@@ -8,19 +8,9 @@ set -o nounset
 # The will be present in a read-only directory
 READS=$2
 
-# The second argument is a directory with write-access where the final
-# assembly should be written to.
-DIR=$3
-
-# The assembly should be written to the file "contigs.fa" in the output directory
-ASSEMBLY=$DIR/contigs.fa
+OUTPUT=/bbx/output
 
 CPU=$(nproc)
-
-# Setup logging
-LOG=$DIR/log.txt
-exec > >(tee ${LOG})
-exec 2>&1
 
 TMP_DIR=`mktemp -d`
 cd ${TMP_DIR}
@@ -36,4 +26,4 @@ sga filter -x 2 -t ${CPU} reads.ec.fastq
 sga overlap -m ${MIN_OVERLAP} -t ${CPU} reads.ec.filter.pass.fa
 sga assemble -m ${ASSEMBLE_OVERLAP} --min-branch-length ${TRIM_LENGTH} -o assembly reads.ec.filter.pass.asqg.gz
 
-cp assembly-contigs.fa ${ASSEMBLY}
+mv assembly-contigs.fa ${OUTPUT}


### PR DESCRIPTION
Hi,

please merge this if it looks good to you.

Summary:
- velvet specific parameter "-short" removed
- optional logging added, according to new spec (see https://github.com/bioboxes/rfc/blob/master/container/short-read-assembler/rfc.mkd#mounts-1) 
- unbound parameter in run script removed 
